### PR TITLE
Load / Save conventional CSVs

### DIFF
--- a/codraft/core/gui/panel.py
+++ b/codraft/core/gui/panel.py
@@ -699,7 +699,7 @@ class SignalPanel(BasePanel):
         else:
             for delimiter in ("\t", ",", " ", ";"):
                 try:
-                    xydata = np.loadtxt(filename, delimiter=delimiter, comments="#")
+                    xydata = np.loadtxt(filename, delimiter=delimiter, comments="#", skiprows=1)
                     break
                 except ValueError:
                     continue

--- a/codraft/core/gui/panel.py
+++ b/codraft/core/gui/panel.py
@@ -34,10 +34,10 @@ import os.path as osp
 import re
 import warnings
 from typing import List
-import pandas
 
 import guidata.dataset.qtwidgets as gdq
 import numpy as np
+import pandas
 from guidata.configtools import get_icon
 from guidata.qthelpers import add_actions
 from guidata.utils import update_dataset
@@ -80,11 +80,7 @@ from codraft.core.model.signal import (
     create_signal_from_param,
     new_signal_param,
 )
-from codraft.utils.qthelpers import (
-    exec_dialog,
-    qt_try_loadsave_file,
-    save_restore_stds,
-)
+from codraft.utils.qthelpers import exec_dialog, qt_try_loadsave_file, save_restore_stds
 
 #  Registering MetadataItem edit widget
 gdq.DataSetEditLayout.register(MetadataItem, gdq.ButtonWidget)
@@ -700,8 +696,7 @@ class SignalPanel(BasePanel):
             xydata = xydata_dataframe.to_numpy()
         assert len(xydata.shape) in (1, 2), "Data not supported"
         signal = create_signal(osp.basename(filename))
-        signal.xlabel = xydata_dataframe.columns[0]
-        signal.ylabel = xydata_dataframe.columns[1]
+        signal.xlabel, signal.ylabel = xydata_dataframe.columns[:2]
         if len(xydata.shape) == 1:
             signal.set_xydata(np.arange(xydata.size), xydata)
         else:
@@ -720,10 +715,13 @@ class SignalPanel(BasePanel):
         if filename:
             with qt_try_loadsave_file(self.parent(), filename, "save"):
                 Conf.main.base_dir.set(filename)
-                np.savetxt(filename, obj.xydata.T, 
-                           header=",".join([obj.xlabel or "X", obj.ylabel or "Y"]), 
-                           delimiter=",",
-                           comments="")
+                np.savetxt(
+                    filename,
+                    obj.xydata.T,
+                    header=",".join([obj.xlabel or "X", obj.ylabel or "Y"]),
+                    delimiter=",",
+                    comments="",
+                )
 
 
 class ImagePanel(BasePanel):

--- a/codraft/core/gui/panel.py
+++ b/codraft/core/gui/panel.py
@@ -35,6 +35,8 @@ import re
 import warnings
 from typing import List
 
+import sys
+
 import guidata.dataset.qtwidgets as gdq
 import numpy as np
 from guidata.configtools import get_icon
@@ -697,7 +699,7 @@ class SignalPanel(BasePanel):
         else:
             for delimiter in ("\t", ",", " ", ";"):
                 try:
-                    xydata = np.loadtxt(filename, delimiter=delimiter)
+                    xydata = np.loadtxt(filename, delimiter=delimiter, comments="#")
                     break
                 except ValueError:
                     continue
@@ -723,7 +725,9 @@ class SignalPanel(BasePanel):
         if filename:
             with qt_try_loadsave_file(self.parent(), filename, "save"):
                 Conf.main.base_dir.set(filename)
-                np.savetxt(filename, obj.xydata, delimiter=",")
+                np.savetxt(filename, obj.xydata.T, 
+                           header=",".join([obj.xlabel or "X", obj.ylabel or "Y"]), 
+                           delimiter=",", comments="#")
 
 
 class ImagePanel(BasePanel):

--- a/codraft/data/tests/curve_formats/paracetamol.txt
+++ b/codraft/data/tests/curve_formats/paracetamol.txt
@@ -7,6 +7,7 @@
 ##DESCRIPTION=Fine colorless powder. Paracetamol, otherwise known as acetaminophen, is an analgesic and antipyretic.
 ##STATUS=The identification of this mineral is not yet confirmed.
 ##URL=rruff.info/D120007
+Wave Numbers (cm-1), Intensity
 5, 144.95
 5.05, 130.958
 5.1, 138.617
@@ -1007,6 +1008,3 @@
 54.85, 59.1623
 54.9, 61.9758
 ##END=
-
-
-

--- a/dev/pip_list.txt
+++ b/dev/pip_list.txt
@@ -41,6 +41,7 @@ networkx                      2.8
 numpy                         1.21.0
 opencv-python                 4.5.2.54
 packaging                     21.3
+pandas                        1.4.3
 pathspec                      0.9.0
 pbr                           5.8.1
 pefile                        2021.9.3

--- a/dev/requirements.txt
+++ b/dev/requirements.txt
@@ -2,6 +2,7 @@ guidata
 guiqwt
 PythonQwt
 scikit-image
+pandas
 psutil
 pylint
 black

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ install_requires =
     h5py>=3.0
     NumPy>=1.21
     SciPy>=1.7
+    pandas>=1.2
     scikit-image>=0.18
     psutil>=5.5
     guidata>=2.3


### PR DESCRIPTION
I noticed that CodraFT was failing to load all of the CSVs I wanted to test it with, so I generated a signal from within CodraFT and saved it.

CodraFT uses numpy's [savetxt](https://github.com/CODRA-Ingenierie-Informatique/CodraFT/blob/master/codraft/core/gui/panel.py#L726) and [loadtxt](https://github.com/CODRA-Ingenierie-Informatique/CodraFT/blob/master/codraft/core/gui/panel.py#L700) to save and load CSV files.

Without any further adaptation, savetxt and loadtxt will try to save the array mimicking its shape when writing it to the file.

CodraFT's `xydata` is stored as a 2xN array and results in a file that has 2 lines, each line containing N entries. This is in contrast to typical CSVs where we would expect two columns for two variables (X,Y).

This PR gets CodraFT to produce and consume conventional CSVs more easily.

**EDIT:**

I have added here pandas for the loading of CSVs just for consideration. From my point of view it was possible to load at least one example (slightly modified).

![image](https://user-images.githubusercontent.com/1336337/180419345-a69ed0a3-c013-4b23-9ab1-08b3645cb588.png)